### PR TITLE
Bug/env threadx queue

### DIFF
--- a/lib/rpmsg_lite/porting/environment/rpmsg_env_threadx.c
+++ b/lib/rpmsg_lite/porting/environment/rpmsg_env_threadx.c
@@ -611,14 +611,14 @@ int32_t env_create_queue(void **queue,
 int32_t env_create_queue(void **queue, int32_t length, int32_t element_size)
 #endif
 {
-    struct TX_QUEUE *queue_ptr = ((void *)0);
+    TX_QUEUE *queue_ptr = ((void *)0);
     char *msgq_buffer_ptr      = ((void *)0);
 
 #if defined(RL_USE_STATIC_API) && (RL_USE_STATIC_API == 1)
     queue_ptr       = (struct k_msgq *)queue_static_context;
     msgq_buffer_ptr = (char *)queue_static_storage;
 #else
-    queue_ptr       = (struct k_msgq *)env_allocate_memory(sizeof(struct TX_QUEUE));
+    queue_ptr       = env_allocate_memory(sizeof(TX_QUEUE));
     msgq_buffer_ptr = (char *)env_allocate_memory(length * element_size);
 #endif
     if ((queue_ptr == ((void *)0)) || (msgq_buffer_ptr == ((void *)0)))
@@ -627,7 +627,7 @@ int32_t env_create_queue(void **queue, int32_t length, int32_t element_size)
     }
 
     if (TX_SUCCESS ==
-        _tx_queue_create((TX_QUEUE *)queue_ptr, NULL, element_size, (VOID *)msgq_buffer_ptr, (length * element_size)))
+        _tx_queue_create(queue_ptr, NULL, element_size, (VOID *)msgq_buffer_ptr, (length * element_size)))
     {
         *queue = (void *)queue_ptr;
         return 0;


### PR DESCRIPTION
Removed incorrect `struct` keyword and unnecessary casting. This matches use of `TX_QUEUE` in other parts of the file so is probably just a mistake that was left over from a previous change or update to the ThreadX API.

It is using `struct TX_QUEUE` but `TX_QUEUE` is actually a typedef from `tx_api.h`:

```
typedef struct TX_QUEUE_STRUCT {
  ...
} TX_QUEUE;
```

Found it when compiling for NXP RT1170 chip based on `rpmsg-lite` examples ported to ThreadX.

Before change:

```
arm-none-eabi-gcc [ ... lots of arguments ... ] "../rpmsg_lite/rpmsg_lite/porting/environment/rpmsg_env_threadx.c"
../rpmsg_lite/rpmsg_lite/porting/environment/rpmsg_env_threadx.c: In function 'env_create_queue':
../rpmsg_lite/rpmsg_lite/porting/environment/rpmsg_env_threadx.c:621:67: error: invalid application of 'sizeof' to incomplete type 'struct TX_QUEUE'
  621 |     queue_ptr       = (struct k_msgq *)env_allocate_memory(sizeof(struct TX_QUEUE));
      |                                                                   ^~~~~~
```

After change there are no warnings or errors.

I've compiled it with MCU Xpresso and run with my board and it all seems to work.

Please let me know what you think and if this MR is useful or needs any more work to be merged in.

Thanks,

Tim
TTP